### PR TITLE
feat(prefix-configurable): update settings to be able to have prefix

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8.9.4
 # Needed for running yarn build
-ARG API_URLi=http://localhost:7500
+ARG API_URL=http://localhost:7500
 ENV API_URL=$API_URL
 
 WORKDIR /reactapp

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -25,10 +25,11 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import {
   applyRouterMiddleware,
-  browserHistory,
-  Router
+  Router,
+  useRouterHistory
 } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
+import { createHistory } from 'history'
 import { useScroll } from 'react-router-scroll';
 import 'sanitize.css/sanitize.css';
 // Import CSS reset and Global Styles
@@ -42,6 +43,7 @@ import {
 // Import root routes
 import createRoutes from './routes';
 import configureStore from './store';
+
 /* eslint-enable import/no-unresolved, import/extensions */
 
 // Create redux store with history
@@ -49,6 +51,10 @@ import configureStore from './store';
 // Optionally, this could be changed to leverage a created history
 // e.g. `const browserHistory = useRouterHistory(createBrowserHistory)();`
 const initialState = loadState();
+
+const browserHistory = useRouterHistory(createHistory)({
+  basename: process.env.PUBLIC_PATH_PREFIX
+});
 const store = configureStore(initialState, browserHistory);
 store.subscribe(() => {
   saveState(store.getState());

--- a/client/app/store.js
+++ b/client/app/store.js
@@ -21,7 +21,7 @@ export default function configureStore(initialState = {}, history) {
   // 2. sagaMiddleware: Makes redux-sagas work
   // 3. routerMiddleware: Syncs the location/URL path to the state
 
-  const apiURL = process.env.API_URL || ''
+  const apiURL = process.env.API_URL || '';
 
   const middlewares = [
     swaggerMiddleware({ url: `${apiURL}/swagger2.json` }),

--- a/client/internals/webpack/webpack.base.babel.js
+++ b/client/internals/webpack/webpack.base.babel.js
@@ -5,6 +5,12 @@ const material = require('material-colors');
 const path = require('path');
 const webpack = require('webpack');
 const Dotenv = require('dotenv-webpack');
+const CopyPlugin = require('copy-webpack-plugin');
+
+const dotenvPath = path.resolve(__dirname, '..', '..', '.env');
+const publicPathPrefix = `${process.env.PUBLIC_PATH_PREFIX}/`  || '/';
+const swagger2Path = path.resolve(__dirname, '..', '..', 'swagger2.json');
+
 let processEnv = {
   NODE_ENV: JSON.stringify(process.env.NODE_ENV)
 };
@@ -16,7 +22,7 @@ module.exports = (options) => ({
   entry: options.entry,
   output: Object.assign({ // Compile into js/build.js
     path: path.resolve(process.cwd(), 'build'),
-    publicPath: '/',
+    publicPath: publicPathPrefix
   }, options.output), // Merge with env dependent settings
   module: {
     loaders: [{
@@ -72,6 +78,14 @@ module.exports = (options) => ({
     }],
   },
   plugins: options.plugins.concat([
+
+    new CopyPlugin([
+      {
+        from: swagger2Path,
+        to: path.resolve(process.cwd(), 'build')
+      }
+    ]),
+
     new webpack.ProvidePlugin({
       // make fetch available
       fetch: 'exports-loader?self.fetch!whatwg-fetch',
@@ -85,9 +99,8 @@ module.exports = (options) => ({
     }),
     new webpack.NamedModulesPlugin(),
     new Dotenv({
-      path: './.env', // Path to .env file (this is the default)
-      silent: true //If true, all warnings will be surpressed.
-
+      path: dotenvPath,
+      silent: true // If true, all warnings will be surpressed.
     }),
   ]),
   resolve: {

--- a/client/internals/webpack/webpack.prod.babel.js
+++ b/client/internals/webpack/webpack.prod.babel.js
@@ -4,6 +4,10 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const OfflinePlugin = require('offline-plugin');
 
+require('dotenv').config();
+
+const publicPathPrefix = `${process.env.PUBLIC_PATH_PREFIX}/` || '/';
+
 module.exports = require('./webpack.base.babel')({
   // In production, we skip all hot-reloading stuff
   entry: [
@@ -17,6 +21,7 @@ module.exports = require('./webpack.base.babel')({
   },
 
   plugins: [
+
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
       children: true,
@@ -45,8 +50,8 @@ module.exports = require('./webpack.base.babel')({
     // Put it in the end to capture all the HtmlWebpackPlugin's
     // assets manipulations and do leak its manipulations to HtmlWebpackPlugin
     new OfflinePlugin({
-      relativePaths: false,
-      publicPath: '/',
+      relativePaths: true,
+      publicPath: publicPathPrefix,
 
       // No need to cache .htaccess. See http://mxs.is/googmp,
       // this is applied before any match in `caches` section

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2609,7 +2609,7 @@
         },
         "query-string": {
           "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "resolved": "http://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
           "requires": {
@@ -3260,6 +3260,38 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-webpack-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://axags.artifactoryonline.com/axags/api/npm/virtual-bcn-node/copy-webpack-plugin/-/copy-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha1-9AOaeZgjpLVR/aKctX6UMN3hfGg=",
+      "requires": {
+        "bluebird": "^2.10.2",
+        "fs-extra": "^0.26.4",
+        "glob": "^6.0.4",
+        "lodash": "^4.3.0",
+        "minimatch": "^3.0.0",
+        "node-dir": "^0.1.10"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "https://axags.artifactoryonline.com/axags/api/npm/virtual-bcn-node/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+        },
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://axags.artifactoryonline.com/axags/api/npm/virtual-bcn-node/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
     "core-js": {
       "version": "2.5.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
@@ -3865,7 +3897,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -6004,6 +6036,18 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "0.26.7",
+      "resolved": "https://axags.artifactoryonline.com/axags/api/npm/virtual-bcn-node/fs-extra/-/fs-extra-0.26.7.tgz",
+      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
@@ -6876,8 +6920,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -7970,7 +8013,7 @@
     },
     "into-stream": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
@@ -9967,6 +10010,14 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "2.4.0",
+      "resolved": "https://axags.artifactoryonline.com/axags/api/npm/virtual-bcn-node/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -10020,6 +10071,14 @@
       "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
+      }
+    },
+    "klaw": {
+      "version": "1.3.1",
+      "resolved": "https://axags.artifactoryonline.com/axags/api/npm/virtual-bcn-node/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "requires": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "kleur": {
@@ -11088,6 +11147,14 @@
         "lower-case": "^1.1.1"
       }
     },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://axags.artifactoryonline.com/axags/api/npm/virtual-bcn-node/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "requires": {
+        "minimatch": "^3.0.2"
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -12115,7 +12182,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -14731,7 +14798,6 @@
       "version": "2.5.4",
       "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-      "dev": true,
       "requires": {
         "glob": "^7.0.5"
       },
@@ -14740,7 +14806,6 @@
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -15337,7 +15402,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "dev": true,
           "requires": {

--- a/client/package.json
+++ b/client/package.json
@@ -217,6 +217,7 @@
     "babel-polyfill": "6.20.0",
     "chalk": "1.1.3",
     "compression": "1.7.3",
+    "copy-webpack-plugin": "^3.0.0",
     "cross-env": "3.1.3",
     "dotenv-webpack": "^1.5.4",
     "escope": "^3.6.0",


### PR DESCRIPTION
# Pull Request Template

## PR Description
Updated webpack & frontend app configuration to be able to work with prefix in routes. Now it's easier to use the built version in your project.

### Steps:

Go to /client
Generate a .env file (this for example):

```
PUBLIC_PATH_PREFIX=/nlp # routes prefix
API_URL=/nlp # path to get swagger2.json file
```
Generate build (inside /client folder):
```
npm run build
```
This will generate a "build" folder. You only need to copy this folder in your project and add configure your backend to forward there.

## PR Motivation

At this moment is not easy to have it working this dashboard with prefix in routes and it has some refresh issues.
