### PR TITLE
fix(domain-selection): passing domainId per query to block dropdown

### DIFF
--- a/client/app/containers/IntentListPage/index.js
+++ b/client/app/containers/IntentListPage/index.js
@@ -118,7 +118,9 @@ export class IntentListPage extends React.PureComponent { // eslint-disable-line
   }
 
   onCreateAction() {
-    this.props.onChangeUrl('/intents/create');
+    const query = this.state.selectedDomain ? `?domainId=${this.state.selectedDomain.id.toString()}` : '';
+
+    this.props.onChangeUrl(`/intents/create${query}`);
   }
 
   onDeletePrompt(intent) {
@@ -159,7 +161,8 @@ export class IntentListPage extends React.PureComponent { // eslint-disable-line
   }
 
   render() {
-    const { loading, error, agentDomains, domainIntents, currentAgent } = this.props;
+    const { loading, error, agentDomains, domainIntents, currentAgent, location } = this.props;
+    const domainId = location.query.domainId && location.query.domainId;
     const domainProps = {
       loading,
       error,
@@ -213,7 +216,7 @@ export class IntentListPage extends React.PureComponent { // eslint-disable-line
                 type="select"
                 label={messages.domain.defaultMessage}
                 onChange={this.onSelectDomain}
-                value={this.state.selectedDomain ? this.state.selectedDomain.id.toString() : 'default'}
+                value={domainId || (this.state.selectedDomain ? this.state.selectedDomain.id.toString() : 'default')}
               >
                 {this.renderDomainSelectOptions(domainsSelect)}
               </Input>

--- a/client/app/containers/IntentPage/index.js
+++ b/client/app/containers/IntentPage/index.js
@@ -178,6 +178,7 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
   componentDidMount() {
     this.setEditMode(this.props.route.name === 'intentEdit');
     this.props.router.setRouteLeaveHook(this.props.route, this.routerWillLeave);
+
     this.setState({
       userExamplesShown: this.props.intent.examples.slice(0, this.props.defaultUserExamplesPageSize)
     });
@@ -244,7 +245,7 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
       this.setState({findNewSysEntities: true});
       this.props.onFindSysEntities(this.props.currentAgent.id);
     }
-    
+
     if (prevProps.intent.examples.length !== this.props.intent.examples.length ) {
       this.setState({findNewSysEntities: true});
       this.props.onFindSysEntities(this.props.currentAgent.id);
@@ -443,7 +444,10 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
   }
 
   render() {
-    const { loading, error, success, intent, webhook, agentDomains, agentEntities, currentAgent, postFormat } = this.props;
+    const { loading, error, success, intent, webhook, agentDomains, agentEntities, currentAgent, postFormat, location } = this.props;
+
+    const domainId = location.query.domainId && location.query.domainId;
+
     if (_.isNil(agentDomains) && _.isNil(agentEntities)) return undefined;
     const intentProps = {
       loading,
@@ -455,8 +459,9 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
     let domainsSelect = [];
     if (agentDomains !== false) {
       const defaultOption = { value: 'default', text: 'Please choose a domain to place your intent', disabled: 'disabled' };
+
       const options = agentDomains.domains.map((domain) => ({
-        value: domain.domainName,
+        value: domain.id,
         text: domain.domainName,
       }));
       domainsSelect = [defaultOption, ...options];
@@ -474,6 +479,8 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
     else {
       breadcrumbs = [{ label: '+ Creating intents' },];
     }
+
+    const domainValue = domainId ? domainId : (intent.domain ? intent.domain : 'default');
 
     return (
 
@@ -500,8 +507,9 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
                 s={12}
                 type="select"
                 label={messages.domain.defaultMessage}
-                value={intent.domainName ? intent.domainName : 'default'}
+                value={domainValue}
                 onChange={(evt) => this.onChangeInput(evt, 'domainName')}
+                disabled = {domainId || (domainValue !== 'default')}
               >
                 {returnFormattedOptions(domainsSelect)}
               </Input>
@@ -691,7 +699,7 @@ export class IntentPage extends React.PureComponent { // eslint-disable-line rea
               </Table>
             </TableContainer> :
             <TableContainer id="intentResponsesTable" style={{ backgroundColor: '#e2e5ee' }} quotes>
-              <Table>            
+              <Table>
                 <tbody>
                   <tr style={{ width: '100%' }}>
                     <td style={{ width: '100%', display: 'inline-block' }}>


### PR DESCRIPTION
# Pull Request Template

## PR Description

- Disable domain in the case of there's no sense to leave it open to user
- Added support to have preselected & disabled a new creation of intent when you navigate from a domain (forwarding domainId in query)