### PR TITLE
Fix entity languages

### DIFF
--- a/server/trainers/nlpjs-trainer.js
+++ b/server/trainers/nlpjs-trainer.js
@@ -48,7 +48,7 @@ class NlpjsTrainer {
         for (let i = 0; i < entity.examples.length; i += 1) {
           const example = entity.examples[i];
           const optionName = example.value;
-          const language = example.language || manager.languages;
+          const language = example.languages || manager.settings.languages;
           for (let j = 0; j < example.synonyms.length; j += 1) {
             manager.addNamedEntityText(entityName, optionName, language, example.synonyms[j]);
           }


### PR DESCRIPTION
# Pull Request Template

## PR Checklist

- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

The language copied to the trained JSON file was "undefined" in my case. I had to trace back where the languages were taken from and found that language became languages in the example entity, and that manager.languages did not exist anymore and was moved to manager.settings.languages